### PR TITLE
Fix get_face_cubies method to use current 3D positions 

### DIFF
--- a/rubiks-cube/rubiks_cube.py
+++ b/rubiks-cube/rubiks_cube.py
@@ -149,21 +149,30 @@ class RubiksCube(VGroup):
     def get_face_cubies(self, face):
         """
         Get the 9 cubies that belong to a specific face.
-        
+
+        Uses current 3D positions rather than initial grid indices so that
+        face selection remains correct after prior rotations have physically
+        moved cubies to new locations.
+
         Args:
             face: 'U', 'D', 'F', 'B', 'R', or 'L'
         """
-        # Get coordinates based on face
-        coords_map = {
-            'U': [(x, y, 1) for x in [-1, 0, 1] for y in [-1, 0, 1]],
-            'D': [(x, y, -1) for x in [-1, 0, 1] for y in [-1, 0, 1]],
-            'R': [(1, y, z) for y in [-1, 0, 1] for z in [-1, 0, 1]],
-            'L': [(-1, y, z) for y in [-1, 0, 1] for z in [-1, 0, 1]],
-            'F': [(x, 1, z) for x in [-1, 0, 1] for z in [-1, 0, 1]],
-            'B': [(x, -1, z) for x in [-1, 0, 1] for z in [-1, 0, 1]],
+        step = self.cubie_size + self.gap
+        # Threshold is halfway between the center layer (0) and the outer
+        # layer (step), giving plenty of margin for floating-point drift.
+        t = step * 0.5
+
+        face_check = {
+            'U': lambda p: p[2] >  t,
+            'D': lambda p: p[2] < -t,
+            'R': lambda p: p[0] >  t,
+            'L': lambda p: p[0] < -t,
+            'F': lambda p: p[1] >  t,
+            'B': lambda p: p[1] < -t,
         }
-        
-        return VGroup(*[self.get_cubie_by_coords(*coord) for coord in coords_map[face]])
+
+        check = face_check[face]
+        return VGroup(*[c for c in self.cubies if check(c.get_center())])
     
     def get_cubie_by_coords(self, x, y, z):
         """Get a cubie by its grid coordinates (-1, 0, or 1)."""


### PR DESCRIPTION
### Changes

**`rubiks_cube.py` — correct face index mapping**

Manim's `Cube` generates its 6 faces in the order `IN, OUT, LEFT, RIGHT, UP, DOWN`. The original `face_indices` dictionary treated this as `[F, B, L, R, U, D]`, so every face name resolved to the wrong square. The correct mapping is:

| Face | Axis | Manim constant | Index |
|------|------|---------------|-------|
| F    | +y   | UP            | 4     |
| B    | -y   | DOWN          | 5     |
| L    | -x   | LEFT          | 2     |
| R    | +x   | RIGHT         | 3     |
| U    | +z   | OUT           | 1     |
| D    | -z   | IN            | 0     |

With the wrong mapping, the correct exterior face of each cubie was set to `BLACK` while the wrong face received the sticker color, making most of the cube appear black.

**`rubiks_cube.py` — fix `get_face_cubies` to use current 3D positions**

The old implementation selected cubies by hardcoded initial grid indices. After a rotation physically relocated cubies (e.g. an R move moving top-right cubies out of the top layer), the next face selection still fetched them by their stale original indices. This caused the wrong cubies to be included in subsequent face rotations, making it look like multiple layers were moving at once.

The fix queries each cubie's live `get_center()` position and keeps only those whose relevant coordinate exceeds `step * 0.5` (the midpoint between the center slab and the outer slab), which is robust to floating-point drift from repeated rotations.
